### PR TITLE
add CityLAB web dev job offer

### DIFF
--- a/content/jobs/citylab-berlin-webdev-1-2021.md
+++ b/content/jobs/citylab-berlin-webdev-1-2021.md
@@ -1,0 +1,15 @@
+---
+# Title to be displayed with a short description (max. 110 characters)
+title: "Werkstudent*in (x/w/m) Web-Entwicklung (16-20h/Woche)"
+# Date you added this job
+date: 2020-11-10T17:00:00+02:00
+# Date when job offer should disappear from the website
+expirydate: 2021-02-01
+draft: false
+# Name of the company (with department if you want) (e.g. "Wikimedia Foundation, Technology")
+place: "CityLAB Berlin | Technologiestiftung Berlin"
+# Date when the job will start; leave out if starting is flexible; afterwards the listing will disappear (date format "2020-02-02" YYYY-MM-DD)
+start: 2021-01-01
+# Direct link to the job offering (e.g. "https://boards.greenhouse.io/wikimedia/jobs/2083317?gh_src=fd611a951")
+link: "https://www.technologiestiftung-berlin.de/fileadmin/daten/media/publikationen/Archiv/201010_Web-Entwickung_Studi_Stellenanzeige.pdf"
+---


### PR DESCRIPTION
Hey @z3to, I would like to add a working student job offer for CityLAB Berlin.

It's a web dev position, with one of the tasks being data visualisation.

Hope this offer is suitable. 